### PR TITLE
Set default Vite base path for GitHub Pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "vite-react-starter",
+  "name": "dagarealty-site",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vite-react-starter",
+      "name": "dagarealty-site",
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.1",

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,10 +3,12 @@ import process from 'node:process';
 import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 
+const DEFAULT_BASE = '/Mynewwebsite/';
+
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
   return {
     plugins: [react()],
-    base: env.BASE_URL || '/',
+    base: env.BASE_URL || DEFAULT_BASE,
   };
 });


### PR DESCRIPTION
## Summary
- default the Vite `base` configuration to `/Mynewwebsite/` when `BASE_URL` is not provided
- update lockfile metadata after installing dependencies

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0dde20c24832595e08fcc52b989a8